### PR TITLE
Added DSA Card.

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+
 export default function Home() {
   return (
     <section className="grid gap-6 lg:grid-cols-[1fr_340px]">
@@ -55,6 +56,39 @@ export default function Home() {
             ))} 
           </div>
         </div>
+
+        {/* DSA Topic-wise Learning Section */}
+        {/* Learn DSA – Home Entry Point */}
+<div className="overflow-hidden rounded-2xl border border-[#e0d5c2] bg-[#fff8ed] dark:border-[#3c3347] dark:bg-[#211d27]">
+  <div className="border-b border-[#e0d5c2] bg-[#f2e3cc] px-6 py-4 dark:border-[#3c3347] dark:bg-[#292331]">
+    <div className="text-xs font-semibold uppercase tracking-wide text-[#8a7a67] dark:text-[#b5a59c]">
+      Learn
+    </div>
+    <h2 className="mt-2 text-lg font-semibold text-[#2b2116] dark:text-[#f6ede0]">
+      Learn Data Structures & Algorithms
+    </h2>
+    <p className="mt-1 text-sm text-[#5d5245] dark:text-[#d7ccbe]">
+      A structured, topic-wise roadmap to master DSA from basics to advanced.
+    </p>
+  </div>
+
+  <div className="px-6 py-5">
+    <ul className="mb-4 space-y-2 text-sm text-[#5d5245] dark:text-[#d7ccbe]">
+      <li>• Topic-wise learning paths</li>
+      <li>• Curated problems by difficulty</li>
+      <li>• Interview-focused preparation</li>
+    </ul>
+
+    <Link
+      href="/topics"
+      className="inline-flex h-10 items-center justify-center rounded-full bg-[#d69a44] px-6 text-sm font-medium text-[#2b1a09] hover:bg-[#c4852c] dark:bg-[#f2c66f] dark:text-[#231406] dark:hover:bg-[#e4b857]"
+    >
+      View full roadmap →
+    </Link>
+  </div>
+</div>
+
+
       </div>
 
       <aside className="grid gap-4">

--- a/src/app/topics/[slug]/page.jsx
+++ b/src/app/topics/[slug]/page.jsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+// Data
+const TOPIC_PROBLEMS = {
+  arrays: {
+    title: "Arrays",
+    problems: [
+      { title: "Two Sum", slug: "two-sum", diff: "Easy" },
+      { title: "Maximum Subarray", slug: "max-subarray", diff: "Medium" },
+    ],
+  },
+  trees: {
+    title: "Trees",
+    problems: [
+      { title: "Inorder Traversal", slug: "binary-tree-inorder-traversal", diff: "Easy" },
+      { title: "Validate BST", slug: "validate-bst", diff: "Medium" },
+    ],
+  },
+};
+
+// Dynamic route page
+export default function TopicPage({ params }) {
+  // Safety check: params exists
+  if (!params || !params.slug) {
+    notFound();
+  }
+
+  const slug = params.slug.toLowerCase(); // ensure lowercase match
+  const topic = TOPIC_PROBLEMS[slug];
+
+  if (!topic) notFound();
+
+  return (
+    <section className="grid gap-6">
+      <h1 className="text-2xl font-semibold text-[#2b2116] dark:text-[#f6ede0]">
+        {topic.title}
+      </h1>
+
+      <div className="overflow-hidden rounded-2xl border border-[#e0d5c2] bg-[#fff8ed] dark:border-[#3c3347] dark:bg-[#211d27]">
+        <div className="divide-y divide-[#e0d5c2] dark:divide-[#3c3347]">
+          {topic.problems.map((p) => (
+            <Link
+              key={p.slug}
+              href={`/problems/${p.slug}`}
+              className="flex items-center justify-between px-6 py-4 text-sm hover:bg-[#f2e3cc] dark:hover:bg-[#2d2535]"
+            >
+              <span className="text-[#2b2116] dark:text-[#f6ede0]">{p.title}</span>
+              <span className="text-xs text-[#8a7a67] dark:text-[#b5a59c]">{p.diff}</span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/topics/page.jsx
+++ b/src/app/topics/page.jsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { title } from "node:process";
+
+const DSA_TOPICS = [
+  { title: "Arrays", slug: "arrays", description: "Sequential data structures" },
+  { title: "Strings", slug: "strings", description: "Text processing techniques" },
+  { title: "Bit Manipulation", slug: "bit-manipulation", description: "Binary operations" },
+  { title: "Hash Tables", slug: "hash-tables", description: "Key-value storage" },
+  { title: "2 Pointers", slug: "two-pointers", description: "Two-pointer techniques" },
+  { title: "Prefix Sums", slug: "prefix-sums", description: "Efficient range queries" },
+  { title: "Sliding Window", slug: "sliding-window", description: "Efficient window-based algorithms" },
+  { title: "Kadene's Algorithm" , slug: "kadenes-algorithm", description: "Maximum subarray problems" },
+  { title: "Matrix", slug: "matrix", description: "2D array operations" },
+  { title: "Linked List", slug: "linked-list", description: "Dynamic linear structures" },
+  { title: "Stacks & Queues", slug: "stacks-queues", description: "LIFO and FIFO structures" },
+  { title: "Sorting Algorithms", slug: "sorting-algorithms", description: "Data ordering techniques" },
+  { title: "Recursion", slug: "recursion", description: "Self-referential functions" },
+  { title: "Backtracking", slug: "backtracking", description: "Constraint satisfaction" },
+  { title: "Trees", slug: "trees", description: "Hierarchical data structures" },
+  { title: "Graphs", slug: "graphs", description: "Node-edge relationships" },
+];
+
+export default function TopicsPage() {
+  return (
+    <section className="grid gap-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-[#2b2116] dark:text-[#f6ede0]">
+          DSA Roadmap
+        </h1>
+        <p className="mt-1 text-sm text-[#5d5245] dark:text-[#b5a59c]">
+          Choose a topic and start practicing problems.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {DSA_TOPICS.map((topic) => (
+          <Link
+  key={topic.slug}
+  href={`/topics/${topic.slug}`}  // must match TOPIC_PROBLEMS key
+  className="rounded-xl border border-[#e0d5c2] bg-[#fff8ed] p-4 hover:bg-[#f2e3cc] dark:border-[#3c3347] dark:bg-[#211d27] dark:hover:bg-[#2d2535]"
+>
+  <h2 className="text-sm font-semibold text-[#2b2116] dark:text-[#f6ede0]">{topic.title}</h2>
+  <p className="mt-1 text-xs text-[#6f6251] dark:text-[#b5a59c]">{topic.description}</p>
+</Link>
+
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
What this PR does
   - Adds a “Learn DSA” card on the home page as an entry point for learning DSA.
   - The card displays topic-wise headings (e.g., Arrays, Trees) to guide users on how to learn DSA step by step.
   - Clicking “View full roadmap” takes users to the DSA roadmap page (/topics) showing all topics.

## Related issues
Use GitHub auto-close keywords so the issue closes when this PR is merged:

- Fixes #issue97
- Closes #issue97
- Resolves #issue97

## Checklist
- [ ] I ran `npm run lint` locally
- [ ] I ran `npm run build` locally
- [ ✔️] This change is scoped and focused
- [ ] Docs updated (if needed)
